### PR TITLE
Adding telegraf probe to a dockernet topology

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -1,5 +1,17 @@
 - hosts: localhost
   tasks:
+   - name: set 'telegraf' archive name
+     set_fact:
+       telegraf_archive_name: 'telegraf-0.10.2-1_linux_amd64.tar.gz'
+
+   - name: download 'telegraf'
+     get_url: url=http://get.influxdb.org/telegraf/{{telegraf_archive_name}} dest=../util/telegraf/
+
+   - name: extract 'telegraf'
+     shell: tar -xvf {{telegraf_archive_name}}
+     args:
+       chdir: ../util/telegraf
+
    - name: updates apt
      apt: update_cache=yes
 

--- a/examples/dockerhosts.py
+++ b/examples/dockerhosts.py
@@ -48,6 +48,9 @@ def dockerNet():
     net.addLink(d2, s3, params1={"ip": "11.0.0.254/8"})
     net.addLink(d3, s3)
 
+    info('*** Add monitoring\n')
+    p1 = net.addMonitoring(d1, d2)
+
     info('*** Starting network\n')
     net.start()
 

--- a/util/telegraf/.gitignore
+++ b/util/telegraf/.gitignore
@@ -1,0 +1,4 @@
+etc
+usr
+var
+telegraf-*.tar.gz

--- a/util/telegraf/telegraf_wrapper.sh
+++ b/util/telegraf/telegraf_wrapper.sh
@@ -1,0 +1,19 @@
+#! /bin/bash -e
+set -x
+
+F=$1
+TF_URLS=$2
+TF_USERNAME=$3
+TF_PASSWORD=$4
+CONTAINERS=$5
+
+util/telegraf/usr/bin/telegraf -sample-config -input-filter 'cpu:docker' -output-filter 'influxdb' > ${F}
+sed -i "s/debug = false/debug = true/g" ${F}
+#sed -i "s/quiet = false/quiet = true/g" ${F}
+sed -i "s/urls = .*/urls = \[\"${TF_URLS}\"\]/g" ${F}
+sed -i "s/[#] username = .*/username = \"${TF_USERNAME}\"/g" ${F}
+sed -i "s/[#] password = .*/password = \"${TF_PASSWORD}\"/g" ${F}
+sed -i "s/percpu = true/percpu = false/g" ${F}
+sed -i "s/container_names = .*/container_names = \[${CONTAINERS}\]/g" ${F}
+
+exec util/telegraf/usr/bin/telegraf -config ${F}


### PR DESCRIPTION
This PR adds a [telegraf](https://github.com/influxdata/telegraf) probe to a dockernet topology as a mininet `Node`.
It will gather metrics on the docker containers deployed with dockernet.

This PR is just a proof of concept as it feel to "hacky" to be merged.
In particular, mininet suppose that the command started in a Node will finish whereas a probe doesn't.
Perhaps a new version of this PR can be made by creating the probe as basic python sub-process.
