### PR TITLE
Dockernet sonata

### DIFF
--- a/bin/clear_crash.sh
+++ b/bin/clear_crash.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-sudo pkill python
 sudo docker rm -f $(sudo docker ps --filter 'label=com.dockernet' -a -q)
 sudo ./mn -c

--- a/bin/clear_crash.sh
+++ b/bin/clear_crash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 sudo pkill python
-sudo docker rm -f $(sudo docker ps -a -q)
+sudo docker rm -f $(sudo docker ps --filter 'label=com.dockernet' -a -q)
 sudo ./mn -c

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -721,6 +721,7 @@ class Docker ( Host ):
             host_config=hc,
             cpu_shares=self.cpu_shares,
             cpuset=self.cpuset,
+            labels=['com.dockernet'],
         )
         # start the container
         self.dcli.start(self.dc)


### PR DESCRIPTION
This PR puts labels on the containers created by dockernet. 
The helper script for cleaning a mininet topology can now avoid killing all the containers running on the host.
Furthermore, this script stops killing python processes (in particular those not started by mininet).